### PR TITLE
fixed createWalletByDevices arguments since its signature was changed in byteballcore bc9bf048880…

### DIFF
--- a/start.js
+++ b/start.js
@@ -125,7 +125,7 @@ function createWallet(xPrivKey, onDone){
 	device.setDevicePrivateKey(devicePrivKey); // we need device address before creating a wallet
 	var strXPubKey = Bitcore.HDPublicKey(xPrivKey.derive("m/44'/0'/0'")).toString();
 	var walletDefinedByKeys = require('byteballcore/wallet_defined_by_keys.js');
-	walletDefinedByKeys.createWalletByDevices(strXPubKey, 0, 1, [], 'any walletName', function(wallet_id){
+	walletDefinedByKeys.createWalletByDevices(strXPubKey, 0, 1, [], 'any walletName', conf.bSingleAddress, function(wallet_id){
 		walletDefinedByKeys.issueNextAddress(wallet_id, 0, function(addressInfo){
 			onDone();
 		});


### PR DESCRIPTION
The signature of walletDefinedByKeys.createWalletByDevices was changed but the headless-byteball was not updated and so when creating a wallet, it failed with:

```
/root/node_modules/byteballcore/wallet_defined_by_keys.js:237
        handleWallet(wallet);
        ^

TypeError: handleWallet is not a function
    at /root/node_modules/byteballcore/wallet_defined_by_keys.js:237:3
    at /root/node_modules/byteballcore/wallet_defined_by_keys.js:227:39
```