### PR TITLE
callback for unknown text added to method handleText

### DIFF
--- a/start.js
+++ b/start.js
@@ -388,7 +388,7 @@ function issueOrSelectStaticChangeAddress(handleAddress){
 	});
 }
 
-function handleText(from_address, text){
+function handleText(from_address, text, onUnknown){
 	
 	text = text.trim();
 	var fields = text.split(/ /);
@@ -463,7 +463,11 @@ function handleText(from_address, text){
 			break;
 
 		default:
-				return device.sendMessageToDevice(from_address, 'text', "unrecognized command");
+			if (onUnknown){
+				onUnknown(from_address, text);
+			}else{
+				device.sendMessageToDevice(from_address, 'text', "unrecognized command");
+			}
 	}
 }
 


### PR DESCRIPTION
This allows to add a callback to method `handleText` which handles unknown text when headless wallet is `required`.